### PR TITLE
use the "no-cost" tier term

### DIFF
--- a/PREINSTALL.md
+++ b/PREINSTALL.md
@@ -78,7 +78,7 @@ Each PSP also requires a parameter that the extension will store using [Cloud Se
 To install an extension, your project must be on the [Blaze (pay as you go) plan](https://firebase.google.com/pricing)
 
 - You will be charged a small amount (typically around $0.01/month) for the Firebase resources required by this extension (even if it is not used).
-- This extension uses other Firebase and Google Cloud Platform services, which have associated charges if you exceed the service’s free tier:
+- This extension uses other Firebase and Google Cloud Platform services, which have associated charges if you exceed the service’s no-cost tier:
   - Cloud Firestore
   - Cloud Secret Manager
   - Cloud Functions (Node.js 10+ runtime. [See FAQs](https://firebase.google.com/support/faq#extensions-pricing))

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Each PSP also requires a parameter that the extension will store using [Cloud Se
 To install an extension, your project must be on the [Blaze (pay as you go) plan](https://firebase.google.com/pricing)
 
 - You will be charged a small amount (typically around $0.01/month) for the Firebase resources required by this extension (even if it is not used).
-- This extension uses other Firebase and Google Cloud Platform services, which have associated charges if you exceed the service’s free tier:
+- This extension uses other Firebase and Google Cloud Platform services, which have associated charges if you exceed the service’s no-cost tier:
   - Cloud Firestore
   - Cloud Secret Manager
   - Cloud Functions (Node.js 10+ runtime. [See FAQs](https://firebase.google.com/support/faq#extensions-pricing))


### PR DESCRIPTION
We're changing how we use "free" at Firebase.

(googlers see [go/firebase-free-terminology](http://go/firebase-free-terminology))